### PR TITLE
Updated sc_zip() to take zip as a string

### DIFF
--- a/R/distance.R
+++ b/R/distance.R
@@ -2,15 +2,15 @@
 #'
 #' @param sccall Current list of parameters carried forward from prior
 #'     functions in the chain (ignore)
-#' @param zip A zipcode
+#' @param zip A zipcode string
 #' @param distance An integer distance in miles or kilometers
 #' @param km A boolean value set to \code{TRUE} if distance should be
 #'     in kilometers (default is \code{FALSE} for miles)
 #' @examples
 #' \dontrun{
-#' sc_zip(37203)
-#' sc_zip(37203, 50)
-#' sc_zip(37203, 50, km = TRUE)
+#' sc_zip("37203")
+#' sc_zip("37203", 50)
+#' sc_zip("37203", 50, km = TRUE)
 #' }
 
 #' @export
@@ -24,8 +24,8 @@ sc_zip <- function(sccall, zip, distance = 25, km = FALSE) {
     }
 
     ## check second argument
-    if (missing(zip) || !is.numeric(zip) || nchar(zip) != 5) {
-        stop('Must provide a 5-digit zip code.', call. = FALSE)
+    if (missing(zip) || !is.character(zip) || nchar(zip) != 5) {
+        stop('Must provide a 5-digit zip code string.', call. = FALSE)
     }
 
     stub <- '&_zip=' %+% zip %+% '&_distance=' %+% distance
@@ -39,6 +39,3 @@ sc_zip <- function(sccall, zip, distance = 25, km = FALSE) {
     sccall
 
 }
-
-
-


### PR DESCRIPTION
Hello Benjamin, The `sc_zip()` function won't handle zipcodes beginning in 0 as written. It checks if `zip` is numeric but a numeric zip 04122, for example, would end up as 4122 so `nchar(zip)=5` will always be false for zips starting with 0. I think this can be fixed by requiring zip to be a character. 

I only changed examples in the 'distance.R' file. I'm not sure if other examples would need to be updated to reflect that zip needs to be a string and not numeric. 

Here's an example test case I used:  
```
df <- sc_init() %>%
    sc_select(instnm) %>%
    sc_year(2014) %>%
    sc_zip("04122", 5) %>%
    sc_get()
```
:+1:  :turkey: 